### PR TITLE
fix docker-compose.json for runtime schema compatibility

### DIFF
--- a/apps/calibre-web-automated/docker-compose.json
+++ b/apps/calibre-web-automated/docker-compose.json
@@ -1,15 +1,14 @@
 {
-  "schemaVersion": 2,
   "services": [
     {
       "name": "calibre-web-automated",
       "image": "crocodilestick/calibre-web-automated:V3.1.4",
-      "environment": {
-        "PUID": "1000",
-        "PGID": "1000",
-        "TZ": "${TZ}",
-        "HARDCOVER_TOKEN": "${HARDCOVER_TOKEN}"
-      },
+      "environment": [
+        { "key": "PUID", "value": "1000" },
+        { "key": "PGID", "value": "1000" },
+        { "key": "TZ", "value": "${TZ}" },
+        { "key": "HARDCOVER_TOKEN", "value": "${HARDCOVER_TOKEN}" }
+      ],
       "internalPort": 8083,
       "volumes": [
         {

--- a/apps/calibre-web-automated/docker-compose.json
+++ b/apps/calibre-web-automated/docker-compose.json
@@ -1,14 +1,16 @@
 {
+  "$schema": "https://schemas.runtipi.io/v2/dynamic-compose.json",
+  "schemaVersion": 2,
   "services": [
     {
       "name": "calibre-web-automated",
       "image": "crocodilestick/calibre-web-automated:V3.1.4",
-      "environment": [
-        { "key": "PUID", "value": "1000" },
-        { "key": "PGID", "value": "1000" },
-        { "key": "TZ", "value": "${TZ}" },
-        { "key": "HARDCOVER_TOKEN", "value": "${HARDCOVER_TOKEN}" }
-      ],
+      "environment": {
+        "PUID": "1000",
+        "PGID": "1000",
+        "TZ": "${TZ}",
+        "HARDCOVER_TOKEN": "${HARDCOVER_TOKEN}"
+      },
       "internalPort": 8083,
       "volumes": [
         {

--- a/apps/cwa-downloader/docker-compose.json
+++ b/apps/cwa-downloader/docker-compose.json
@@ -1,13 +1,15 @@
 {
+  "$schema": "https://schemas.runtipi.io/v2/dynamic-compose.json",
+  "schemaVersion": 2,
   "services": [
     {
       "name": "cwa-downloader",
       "image": "ghcr.io/calibrain/shelfmark:v1.2.1",
-      "environment": [
-        { "key": "PUID", "value": "1000" },
-        { "key": "PGID", "value": "1000" },
-        { "key": "TZ", "value": "${TZ}" }
-      ],
+      "environment": {
+        "PUID": "1000",
+        "PGID": "1000",
+        "TZ": "${TZ}"
+      },
       "internalPort": 8084,
       "volumes": [
         {

--- a/apps/cwa-downloader/docker-compose.json
+++ b/apps/cwa-downloader/docker-compose.json
@@ -1,14 +1,13 @@
 {
-  "schemaVersion": 2,
   "services": [
     {
       "name": "cwa-downloader",
       "image": "ghcr.io/calibrain/shelfmark:v1.2.1",
-      "environment": {
-        "PUID": "1000",
-        "PGID": "1000",
-        "TZ": "${TZ}"
-      },
+      "environment": [
+        { "key": "PUID", "value": "1000" },
+        { "key": "PGID", "value": "1000" },
+        { "key": "TZ", "value": "${TZ}" }
+      ],
       "internalPort": 8084,
       "volumes": [
         {

--- a/apps/deemix/docker-compose.json
+++ b/apps/deemix/docker-compose.json
@@ -1,18 +1,16 @@
 {
-  "$schema": "https://schemas.runtipi.io/v2/dynamic-compose.json",
-  "schemaVersion": 2,
   "services": [
     {
       "name": "deemix",
       "image": "ghcr.io/bambanah/deemix:v4.5.0",
       "isMain": true,
       "internalPort": 6595,
-      "environment": {
-        "PUID": "1000",
-        "PGID": "1000",
-        "UMASK_SET": "022",
-        "DEEMIX_SINGLE_USER": "true"
-      },
+      "environment": [
+        { "key": "PUID", "value": "1000" },
+        { "key": "PGID", "value": "1000" },
+        { "key": "UMASK_SET", "value": "022" },
+        { "key": "DEEMIX_SINGLE_USER", "value": "true" }
+      ],
       "volumes": [
         {
           "hostPath": "${APP_DATA_DIR}/data/config",

--- a/apps/deemix/docker-compose.json
+++ b/apps/deemix/docker-compose.json
@@ -1,16 +1,18 @@
 {
+  "$schema": "https://schemas.runtipi.io/v2/dynamic-compose.json",
+  "schemaVersion": 2,
   "services": [
     {
       "name": "deemix",
       "image": "ghcr.io/bambanah/deemix:v4.5.0",
       "isMain": true,
       "internalPort": 6595,
-      "environment": [
-        { "key": "PUID", "value": "1000" },
-        { "key": "PGID", "value": "1000" },
-        { "key": "UMASK_SET", "value": "022" },
-        { "key": "DEEMIX_SINGLE_USER", "value": "true" }
-      ],
+      "environment": {
+        "PUID": "1000",
+        "PGID": "1000",
+        "UMASK_SET": "022",
+        "DEEMIX_SINGLE_USER": "true"
+      },
       "volumes": [
         {
           "hostPath": "${APP_DATA_DIR}/data/config",

--- a/apps/prometheus/docker-compose.json
+++ b/apps/prometheus/docker-compose.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://schemas.runtipi.io/v2/dynamic-compose.json",
   "services": [
     {
       "name": "prometheus",
@@ -16,7 +15,7 @@
           "containerPath": "/prometheus"
         }
       ],
-      "environment": {}
+      "environment": []
     },
     {
       "name": "node-exporter",
@@ -84,6 +83,5 @@
         }
       ]
     }
-  ],
-  "schemaVersion": 2
+  ]
 }

--- a/apps/prometheus/docker-compose.json
+++ b/apps/prometheus/docker-compose.json
@@ -1,4 +1,6 @@
 {
+  "$schema": "https://schemas.runtipi.io/v2/dynamic-compose.json",
+  "schemaVersion": 2,
   "services": [
     {
       "name": "prometheus",
@@ -15,7 +17,7 @@
           "containerPath": "/prometheus"
         }
       ],
-      "environment": []
+      "environment": {}
     },
     {
       "name": "node-exporter",

--- a/apps/wanderer/docker-compose.json
+++ b/apps/wanderer/docker-compose.json
@@ -4,11 +4,11 @@
       "name": "search",
       "container_name": "wanderer-search",
       "image": "getmeili/meilisearch:v1.11.3",
-      "environment": {
-        "MEILI_URL": "http://search:7700",
-        "MEILI_MASTER_KEY": "vODkljPcfFANYNepCHyDyGjzAMPcdHnrb6X5KyXQPWo",
-        "MEILI_NO_ANALYTICS": "true"
-      },
+      "environment": [
+        { "key": "MEILI_URL", "value": "http://search:7700" },
+        { "key": "MEILI_MASTER_KEY", "value": "vODkljPcfFANYNepCHyDyGjzAMPcdHnrb6X5KyXQPWo" },
+        { "key": "MEILI_NO_ANALYTICS", "value": "true" }
+      ],
       "ports": ["7700:7700"],
       "networks": ["wanderer"],
       "volumes": [{"hostPath": "${APP_DATA_DIR}/data/data.ms", "containerPath": "/meili_data/data.ms"}],
@@ -28,12 +28,12 @@
       "depends_on": {
         "search": { "condition": "service_healthy" }
       },
-      "environment": {
-        "MEILI_URL": "http://search:7700",
-        "MEILI_MASTER_KEY": "vODkljPcfFANYNepCHyDyGjzAMPcdHnrb6X5KyXQPWo",
-        "POCKETBASE_ENCRYPTION_KEY": "<YOUR_ENCRYPTION_KEY_HERE>",
-        "ORIGIN": "http://localhost:3000"
-      },
+      "environment": [
+        { "key": "MEILI_URL", "value": "http://search:7700" },
+        { "key": "MEILI_MASTER_KEY", "value": "vODkljPcfFANYNepCHyDyGjzAMPcdHnrb6X5KyXQPWo" },
+        { "key": "POCKETBASE_ENCRYPTION_KEY", "value": "<YOUR_ENCRYPTION_KEY_HERE>" },
+        { "key": "ORIGIN", "value": "http://localhost:3000" }
+      ],
       "ports": ["8090:8090"],
       "networks": ["wanderer"],
       "restart": "unless-stopped",
@@ -49,19 +49,19 @@
         "search": { "condition": "service_healthy" },
         "db": { "condition": "service_started" }
       },
-      "environment": {
-        "MEILI_URL": "http://search:7700",
-        "MEILI_MASTER_KEY": "vODkljPcfFANYNepCHyDyGjzAMPcdHnrb6X5KyXQPWo",
-        "ORIGIN": "http://localhost:3000",
-        "BODY_SIZE_LIMIT": "Infinity",
-        "PUBLIC_POCKETBASE_URL": "http://db:8090",
-        "PUBLIC_DISABLE_SIGNUP": "false",
-        "UPLOAD_FOLDER": "/app/uploads",
-        "UPLOAD_USER": "",
-        "UPLOAD_PASSWORD": "",
-        "PUBLIC_VALHALLA_URL": "https://valhalla1.openstreetmap.de",
-        "PUBLIC_NOMINATIM_URL": "https://nominatim.openstreetmap.org"
-      },
+      "environment": [
+        { "key": "MEILI_URL", "value": "http://search:7700" },
+        { "key": "MEILI_MASTER_KEY", "value": "vODkljPcfFANYNepCHyDyGjzAMPcdHnrb6X5KyXQPWo" },
+        { "key": "ORIGIN", "value": "http://localhost:3000" },
+        { "key": "BODY_SIZE_LIMIT", "value": "Infinity" },
+        { "key": "PUBLIC_POCKETBASE_URL", "value": "http://db:8090" },
+        { "key": "PUBLIC_DISABLE_SIGNUP", "value": "false" },
+        { "key": "UPLOAD_FOLDER", "value": "/app/uploads" },
+        { "key": "UPLOAD_USER", "value": "" },
+        { "key": "UPLOAD_PASSWORD", "value": "" },
+        { "key": "PUBLIC_VALHALLA_URL", "value": "https://valhalla1.openstreetmap.de" },
+        { "key": "PUBLIC_NOMINATIM_URL", "value": "https://nominatim.openstreetmap.org" }
+      ],
       "volumes": [{"hostPath": "${APP_DATA_DIR}/data/uploads", "containerPath": "/app/uploads"}],
       "ports": ["3000:3000"],
       "networks": ["wanderer"],

--- a/apps/wanderer/docker-compose.json
+++ b/apps/wanderer/docker-compose.json
@@ -1,14 +1,16 @@
 {
+  "$schema": "https://schemas.runtipi.io/v2/dynamic-compose.json",
+  "schemaVersion": 2,
   "services": [
     {
       "name": "search",
       "container_name": "wanderer-search",
       "image": "getmeili/meilisearch:v1.11.3",
-      "environment": [
-        { "key": "MEILI_URL", "value": "http://search:7700" },
-        { "key": "MEILI_MASTER_KEY", "value": "vODkljPcfFANYNepCHyDyGjzAMPcdHnrb6X5KyXQPWo" },
-        { "key": "MEILI_NO_ANALYTICS", "value": "true" }
-      ],
+      "environment": {
+        "MEILI_URL": "http://search:7700",
+        "MEILI_MASTER_KEY": "vODkljPcfFANYNepCHyDyGjzAMPcdHnrb6X5KyXQPWo",
+        "MEILI_NO_ANALYTICS": "true"
+      },
       "ports": ["7700:7700"],
       "networks": ["wanderer"],
       "volumes": [{"hostPath": "${APP_DATA_DIR}/data/data.ms", "containerPath": "/meili_data/data.ms"}],
@@ -28,12 +30,12 @@
       "depends_on": {
         "search": { "condition": "service_healthy" }
       },
-      "environment": [
-        { "key": "MEILI_URL", "value": "http://search:7700" },
-        { "key": "MEILI_MASTER_KEY", "value": "vODkljPcfFANYNepCHyDyGjzAMPcdHnrb6X5KyXQPWo" },
-        { "key": "POCKETBASE_ENCRYPTION_KEY", "value": "<YOUR_ENCRYPTION_KEY_HERE>" },
-        { "key": "ORIGIN", "value": "http://localhost:3000" }
-      ],
+      "environment": {
+        "MEILI_URL": "http://search:7700",
+        "MEILI_MASTER_KEY": "vODkljPcfFANYNepCHyDyGjzAMPcdHnrb6X5KyXQPWo",
+        "POCKETBASE_ENCRYPTION_KEY": "<YOUR_ENCRYPTION_KEY_HERE>",
+        "ORIGIN": "http://localhost:3000"
+      },
       "ports": ["8090:8090"],
       "networks": ["wanderer"],
       "restart": "unless-stopped",
@@ -49,19 +51,19 @@
         "search": { "condition": "service_healthy" },
         "db": { "condition": "service_started" }
       },
-      "environment": [
-        { "key": "MEILI_URL", "value": "http://search:7700" },
-        { "key": "MEILI_MASTER_KEY", "value": "vODkljPcfFANYNepCHyDyGjzAMPcdHnrb6X5KyXQPWo" },
-        { "key": "ORIGIN", "value": "http://localhost:3000" },
-        { "key": "BODY_SIZE_LIMIT", "value": "Infinity" },
-        { "key": "PUBLIC_POCKETBASE_URL", "value": "http://db:8090" },
-        { "key": "PUBLIC_DISABLE_SIGNUP", "value": "false" },
-        { "key": "UPLOAD_FOLDER", "value": "/app/uploads" },
-        { "key": "UPLOAD_USER", "value": "" },
-        { "key": "UPLOAD_PASSWORD", "value": "" },
-        { "key": "PUBLIC_VALHALLA_URL", "value": "https://valhalla1.openstreetmap.de" },
-        { "key": "PUBLIC_NOMINATIM_URL", "value": "https://nominatim.openstreetmap.org" }
-      ],
+      "environment": {
+        "MEILI_URL": "http://search:7700",
+        "MEILI_MASTER_KEY": "vODkljPcfFANYNepCHyDyGjzAMPcdHnrb6X5KyXQPWo",
+        "ORIGIN": "http://localhost:3000",
+        "BODY_SIZE_LIMIT": "Infinity",
+        "PUBLIC_POCKETBASE_URL": "http://db:8090",
+        "PUBLIC_DISABLE_SIGNUP": "false",
+        "UPLOAD_FOLDER": "/app/uploads",
+        "UPLOAD_USER": "",
+        "UPLOAD_PASSWORD": "",
+        "PUBLIC_VALHALLA_URL": "https://valhalla1.openstreetmap.de",
+        "PUBLIC_NOMINATIM_URL": "https://nominatim.openstreetmap.org"
+      },
       "volumes": [{"hostPath": "${APP_DATA_DIR}/data/uploads", "containerPath": "/app/uploads"}],
       "ports": ["3000:3000"],
       "networks": ["wanderer"],


### PR DESCRIPTION
Remove schemaVersion field and convert environment from object to array [{key, value}] format across all apps to match the Runtipi runtime's expected schema.