### PR TITLE
feat(session-app): add PRODUCTION env flag to pb service

### DIFF
--- a/apps/session-app/docker-compose.json
+++ b/apps/session-app/docker-compose.json
@@ -18,6 +18,9 @@
       "name": "session-app-pb",
       "image": "ghcr.io/ashooner/session-app-pb:0.1.1",
       "internalPort": 8090,
+      "environment": [
+        { "key": "PRODUCTION", "value": "true" }
+      ],
       "volumes": [
         { "hostPath": "${APP_DATA_DIR}/data/pb_data", "containerPath": "/app/pb_data" }
       ]


### PR DESCRIPTION
Enables seed migration guards in session-app-pb — test users and seed content are skipped, first-run onboarding flow is activated.